### PR TITLE
Potential fix for code scanning alert no. 7: DOM text reinterpreted as HTML

### DIFF
--- a/alpha/index.html
+++ b/alpha/index.html
@@ -251,13 +251,27 @@
             });
         });
         
+        function isValidUrl(url) {
+            const pattern = new RegExp('^(https?:\\/\\/)?'+ // protocol
+                '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|'+ // domain name
+                '((\\d{1,3}\\.){3}\\d{1,3}))'+ // OR ip (v4) address
+                '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*'+ // port and path
+                '(\\?[;&a-z\\d%_.~+=-]*)?'+ // query string
+                '(\\#[-a-z\\d_]*)?$','i'); // fragment locator
+            return !!pattern.test(url);
+        }
+
         function attachClickEvent() {
             document.querySelectorAll("#songList li").forEach(item => {
                 item.addEventListener("click", function () {
                     let videoId = this.getAttribute("data-video");
                     let thumbnail = this.getAttribute("data-img");
 
-                    document.getElementById("albumArt").src = thumbnail;
+                    if (isValidUrl(thumbnail)) {
+                        document.getElementById("albumArt").src = thumbnail;
+                    } else {
+                        console.error("Invalid thumbnail URL");
+                    }
                     loadVideo(videoId);
                 });
             });


### PR DESCRIPTION
Potential fix for [https://github.com/Jacob7179/YouTube-Music-Player-Web/security/code-scanning/7](https://github.com/Jacob7179/YouTube-Music-Player-Web/security/code-scanning/7)

To fix the problem, we need to ensure that the `thumbnail` value is properly sanitized before being used as the `src` attribute of an `img` element. One way to achieve this is by validating the URL to ensure it is a legitimate image URL. We can use a regular expression to check if the URL is valid and only then assign it to the `src` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
